### PR TITLE
Feature/enable dark theme

### DIFF
--- a/apps/block_scout_web/assets/css/_mixins.scss
+++ b/apps/block_scout_web/assets/css/_mixins.scss
@@ -135,7 +135,7 @@
   color: $text-color;
   cursor: pointer;
   display: flex;
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 600;
   height: 36px;
   justify-content: center;

--- a/apps/block_scout_web/assets/css/components/_card.scss
+++ b/apps/block_scout_web/assets/css/components/_card.scss
@@ -51,8 +51,8 @@ $card-tab-icon-color-active: #fff !default;
 }
 
 .card-title {
-  font-size: 18px;
-  font-weight: normal;
+  font-size: 28px;
+  font-weight: 600;
   line-height: 1.2rem;
   margin-bottom: 2rem;
 

--- a/apps/block_scout_web/assets/css/components/_dashboard-banner.scss
+++ b/apps/block_scout_web/assets/css/components/_dashboard-banner.scss
@@ -129,7 +129,7 @@ $dashboard-banner-chart-axis-font-color: $dashboard-stats-item-value-color !defa
     color: $dashboard-banner-chart-legend-label-color;
     display: block;
     font-size: 12px;
-    font-weight: 600;
+    font-weight: 700;
     line-height: 1.2;
     margin: 0 0 5px;
 
@@ -251,7 +251,7 @@ $dashboard-banner-chart-axis-font-color: $dashboard-stats-item-value-color !defa
 
     .dashboard-banner-network-stats-label {
       font-size: 12px;
-      font-weight: 600;
+      font-weight: 700;
       margin: 0;
     }
   }

--- a/apps/block_scout_web/assets/css/components/_navbar.scss
+++ b/apps/block_scout_web/assets/css/components/_navbar.scss
@@ -29,7 +29,8 @@ $navbar-logo-width: auto !default;
       align-items: center;
       color: $header-links-color;
       display: flex;
-      font-size: 14px;
+      font-size: 16px;
+      font-weight: 600;
       position: relative;
       transition: $transition-cont;
 

--- a/apps/block_scout_web/assets/css/components/_tile.scss
+++ b/apps/block_scout_web/assets/css/components/_tile.scss
@@ -188,7 +188,7 @@ $tile-body-a-color: #5959d8 !default;
 
   .tile-title {
     color: $tile-title-color;
-    font-size: 12px;
+    font-size: 14px;
 
     &-hash {
       font-weight: 300;

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -1,9 +1,12 @@
-$body-dark: #1c1d31; // body background
-$dark-bg: #22223a; // hero shade
-$dark-light-bg: #282945; // pills bg shade
-$dark-light: #313355; // tile light top share
+$body-dark: #051221; // body background
+$dark-bg: rgba(255, 255, 255, 0.05); // hero shade
+$dark-light-bg: #0b1426; // pills bg shade
+$dark-light: rgba(17,153,250,.1); // tile light top share
 $labels-dark: #8a8dba; // header nav, labels
 $dark-stakes-banned-background: #3e314c;
+$dark-card-bg: rgba(255, 255, 255, 0.05);
+$dark-card-tile-bg: rgba(17,153,250,.1);
+$dark-dropdown-menu-bg: #151e2b;
 
 // Switcher
 .dark-mode-changer {
@@ -124,7 +127,7 @@ $dark-stakes-banned-background: #3e314c;
 	}
 
 	.card {
-		background-color: $dark-light-bg;
+		background-color: $dark-card-bg;
 		box-shadow: 0 0 30px 0 rgba(23, 24, 41, 0.5);
 	}
 
@@ -162,16 +165,16 @@ $dark-stakes-banned-background: #3e314c;
 	}
 
 	.tile {
-		border-top-color: $dark-light;
-		border-bottom-color: $dark-light;
-		border-right-color: $dark-light;
-		background-color: $dark-light;
+		border-top-color: transparent;
+		border-bottom-color: transparent;
+		border-right-color: transparent;
+		background-color: $dark-card-tile-bg;
 		color: $labels-dark;
 		&:not([class^="tile tile-type"]) {
-			border-left-color: $dark-light;
+			border-left-color: transparent;
 		}
 		&.tile-type-coin-balance {
-			border-left-color: $dark-light;
+			border-left-color: transparent;
 		}
 		.tile-title {
 			color: #fff;
@@ -276,10 +279,10 @@ $dark-stakes-banned-background: #3e314c;
 
 	// dropdown
 	.dropdown-menu {
-		background-color: $dark-light;
-		border-left-color: $dark-light;
-		border-right-color: $dark-light;
-		border-bottom-color: $dark-light;
+		background-color: $dark-dropdown-menu-bg;
+		border-left-color: $dark-dropdown-menu-bg;
+		border-right-color: $dark-dropdown-menu-bg;
+		border-bottom-color: $dark-dropdown-menu-bg;
 	}
 
 	.dropdown-item {
@@ -1006,6 +1009,14 @@ $dark-stakes-banned-background: #3e314c;
 		color: #fff;
 	}
 
+	.bs-label {
+		background: #1199FA;
+	}
+
+	.bs-label.method {
+		color: #fff
+	}
+
 	.bs-label.omni {
 		background: #6ca1e2
 	}
@@ -1112,7 +1123,7 @@ $dark-stakes-banned-background: #3e314c;
 .dark-theme-applied .dropdown-item.active:not(.header), .dark-theme-applied .dropdown-item:not(.header):hover, .dark-theme-applied .dropdown-item:not(.header):focus {
     background-image: none;
     width: 100%;
-    background-color: #3f426c !important;
+    background-color: #1b3049 !important;
 }
 
 @media (max-width: 991.98px) {

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -7,6 +7,8 @@ $dark-stakes-banned-background: #3e314c;
 $dark-card-bg: rgba(255, 255, 255, 0.05);
 $dark-card-tile-bg: rgba(17,153,250,.1);
 $dark-dropdown-menu-bg: #151e2b;
+$dark-subtitle-color: #fff; //
+$dark-btn-hover-bg: #43aefb;
 
 // Switcher
 .dark-mode-changer {
@@ -114,7 +116,7 @@ $dark-dropdown-menu-bg: #151e2b;
 	}
 	.dashboard-banner-network-stats-label,
 	.dashboard-banner-chart-legend .dashboard-banner-chart-legend-label {
-		color: $labels-dark;
+		color: $dark-subtitle-color;
 	}
 	.dashboard-banner-chart-legend .dashboard-banner-chart-legend-item:nth-child(1)::before {
 		background-color: $dark-primary;
@@ -240,12 +242,12 @@ $dark-dropdown-menu-bg: #151e2b;
 	// btns
 
 	.btn-line {
-		background-color: transparent;
+		background-color: $dark-primary;
 		border-color: $dark-primary;
-		color: $dark-primary;
+		color: $dark-subtitle-color;
 		&:hover {
 			border-color: $dark-primary;
-			background-color: $dark-primary;
+			background-color: $dark-btn-hover-bg;
 			color: #fff;
 		}
 	}
@@ -1096,7 +1098,7 @@ $dark-dropdown-menu-bg: #151e2b;
 		  }
 	}
 	.main-search-autocomplete {
-		background-color: $dark-bg !important;
+		background-color: transparent !important;
 		color: #fff !important;
 	}
 	ul[id^='autoComplete_list_'] {

--- a/apps/block_scout_web/assets/css/theme/_dark-theme.scss
+++ b/apps/block_scout_web/assets/css/theme/_dark-theme.scss
@@ -38,6 +38,11 @@ $dark-dropdown-menu-bg: #151e2b;
 .dark-theme-applied {
 	color: #fff;
 
+	// search icon
+	.tokens-list-search-input-container:before {
+		background: url("data:image/svg+xml,%3Csvg%20viewBox%3D%220%200%2016%2017%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2217%22%3E%0A%20%20%20%20%3Cpath%20fill%3D%22%231199fa%22%20fill-rule%3D%22evenodd%22%20d%3D%22M15.713%2015.727a.982.982%200%200%201-1.388%200l-2.289-2.29C10.773%2014.403%209.213%2015%207.5%2015A7.5%207.5%200%201%201%2015%207.5c0%201.719-.602%203.284-1.575%204.55l2.288%202.288a.983.983%200%200%201%200%201.389zM7.5%202a5.5%205.5%200%201%200%200%2011%205.5%205.5%200%201%200%200-11z%22%2F%3E%0A%3C%2Fsvg%3E") center / contain no-repeat;
+	}
+
 	// navbar
 	.navbar.navbar-primary {
 		background-color: $dark-light-bg;

--- a/apps/block_scout_web/assets/css/theme/_neutral_variables.scss
+++ b/apps/block_scout_web/assets/css/theme/_neutral_variables.scss
@@ -75,9 +75,9 @@ $api-text-monospace-color: $primary;
 }
 
 // Dark theme
-$dark-primary: #01040a;
+$dark-primary: #1199fa;
 $dark-secondary: #156abb;
-$dark-primary-alternate: #01040a; 
+$dark-primary-alternate: #1199fa;
 
 .transaction__link {
 	color: $secondary !important

--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -3,7 +3,7 @@
 <nav class="navbar navbar-dark navbar-expand-lg navbar-primary" data-selector="navbar" id="top-navbar">
   <script>
     if (localStorage.getItem("current-color-mode") === "dark") {
-      document.getElementById("top-navbar").style.backgroundColor = "#282945";
+      document.getElementById("top-navbar").style.backgroundColor = "#0b1426";
     }
   </script>
   <div class="container-fluid navbar-container">
@@ -173,11 +173,11 @@
         <% end %>
       </ul>
       <!-- Dark mode changer -->
-      <%# <button class="dark-mode-changer" id="dark-mode-changer">
+      <button class="dark-mode-changer" id="dark-mode-changer">
         <svg xmlns="http://www.w3.org/2000/svg" width="15" height="16">
             <path fill="#9B62FF" fill-rule="evenodd" d="M14.88 11.578a.544.544 0 0 0-.599-.166 5.7 5.7 0 0 1-1.924.321c-3.259 0-5.91-2.632-5.91-5.866 0-1.947.968-3.759 2.59-4.849a.534.534 0 0 0-.225-.97A5.289 5.289 0 0 0 8.059 0C3.615 0 0 3.588 0 8s3.615 8 8.059 8c2.82 0 5.386-1.423 6.862-3.806a.533.533 0 0 0-.041-.616z"/>
         </svg>
-      </button> %>
+      </button>
       <%= render BlockScoutWeb.LayoutView, "_search.html", conn: @conn, id: "main-search-autocomplete", additional_classes: ["mobile-search-hide"] %>
     </div>
   </div>


### PR DESCRIPTION
Problem: (Fix [#3](https://github.com/crypto-org-chain/cronos-blockscout/issues/3)) Enable the dark theme. 

The following image shows the dark mode view:

home page:
<img width="1717" alt="home-page" src="https://user-images.githubusercontent.com/87299790/128168021-4caa7523-30e9-43c6-a76d-5ca959c4393f.png">

blocks page:
<img width="1715" alt="blocks-page" src="https://user-images.githubusercontent.com/87299790/128168059-3c1f1e04-3448-4d21-9e73-30d536c23182.png">

transactions page:
<img width="1719" alt="txs-page" src="https://user-images.githubusercontent.com/87299790/128168227-5a970e54-c921-4fcb-b930-c9dcbad92f3a.png">

account page:
<img width="1711" alt="account-page" src="https://user-images.githubusercontent.com/87299790/128168256-4868aa6e-abc4-4b76-8e11-2f50c79b1cc7.png">

tokens page:
<img width="1718" alt="tokens-page" src="https://user-images.githubusercontent.com/87299790/128168290-068e411e-bdb7-4145-a526-d6cd49b814b1.png">

block detail page: 
<img width="1715" alt="blocks-detail-page" src="https://user-images.githubusercontent.com/87299790/128168355-c5ed05d8-ee73-4d9d-9bca-ed0c75163327.png">

transaction detail page:
<img width="1711" alt="tx-detail-page" src="https://user-images.githubusercontent.com/87299790/128168393-47511bfd-a62f-42d7-a9cb-e50a7a51d316.png">

address detail page:
<img width="1711" alt="address-detail-page" src="https://user-images.githubusercontent.com/87299790/128168433-81a45e82-2e31-456c-b7e2-e3aea31ecbc4.png">

token detail page:
<img width="1716" alt="tokens-detail-page" src="https://user-images.githubusercontent.com/87299790/128168462-c0e19d66-406a-4ad9-829e-bdcdcef34a17.png">
