### PR TITLE
refetch coin balance on address balance page query

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/coin_balance_on_demand.ex
+++ b/apps/indexer/lib/indexer/fetcher/coin_balance_on_demand.ex
@@ -7,7 +7,7 @@ defmodule Indexer.Fetcher.CoinBalanceOnDemand do
   If we have a fetched coin balance, but it is over 100 blocks old, we will fetch and create a fetched coin baalnce.
   """
 
-  @latest_balance_stale_threshold :timer.hours(24)
+  @latest_balance_stale_threshold :timer.seconds(1)
 
   use GenServer
   use Indexer.Fetcher


### PR DESCRIPTION
This triggers an address balance fetch every time a user renders an address page