### PR TITLE
network switcher dropdown

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
+++ b/apps/block_scout_web/lib/block_scout_web/templates/layout/_topnav.html.eex
@@ -140,6 +140,39 @@
             </div>
           </li>
         <% end %>
+        <li class="nav-item dropdown">
+            <a href="#" role="button" id="navbarAPIsDropdown" class="nav-link topnav-nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <%= if System.get_env("CHAIN_NETWORK") == "mainnet" do %>
+                <%= gettext("Cronos EVM Mainnet") %>
+              <% else %>
+                <%= gettext("Cronos EVM Testnet") %>
+              <% end %>
+            </a>
+            <div class="dropdown-menu" aria-labeledby="navbarTransactionsDropdown">
+              <h6 class="dropdown-header"><%= gettext("Mainnets")%></h6>
+              <%= link(
+                    gettext("Cronos Cosmos Mainnet"),
+                    class: "dropdown-item #{tab_status("graphiql", @conn.request_path)}",
+                    to: System.get_env("COSMOS_EXPLORER_MAINNET_URL") || ""
+                  ) %>
+              <%= link(
+                    gettext("Cronos EVM Mainnet"),
+                    class: "dropdown-item #{tab_status("api-docs", @conn.request_path)}",
+                    to: System.get_env("EVM_EXPLORER_MAINNET_URL") || ""
+                  ) %>
+              <h6 class="dropdown-header"><%= gettext("Testnets")%></h6>
+              <%= link(
+                    gettext("Cronos Cosmos Testnet"),
+                    class: "dropdown-item #{tab_status("graphiql", @conn.request_path)}",
+                    to: System.get_env("COSMOS_EXPLORER_TESTNET_URL") || ""
+                  ) %>
+              <%= link(
+                    gettext("Cronos EVM Testnet"),
+                    class: "dropdown-item #{tab_status("api-docs", @conn.request_path)}",
+                    to: System.get_env("EVM_EXPLORER_TESTNET_URL") || ""
+                  ) %>
+            </div>
+          </li>
         <%= if apps_menu == true || staking_enabled_in_menu do %>
           <li class="nav-item dropdown">
             <a href="#" role="button" id="navbarAppsDropdown" class="nav-link topnav-nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/apps/block_scout_web/priv/gettext/default.pot
+++ b/apps/block_scout_web/priv/gettext/default.pot
@@ -226,7 +226,7 @@ msgid "Approximate Current Annual Percentage Yield. If you see N/A, please wait 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:150
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:183
 msgid "Apps"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgid "Staker's Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:152
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:185
 msgid "Stakes"
 msgstr ""
 
@@ -1795,7 +1795,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:158
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:191
 msgid "Staking"
 msgstr ""
 
@@ -2984,4 +2984,36 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:41
 msgid "CRO Price"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
+msgid "Cronos Cosmos Mainnet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:165
+msgid "Cronos Cosmos Testnet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:146
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:159
+msgid "Cronos EVM Mainnet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:148
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:170
+msgid "Cronos EVM Testnet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:152
+msgid "Mainnets"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:163
+msgid "Testnets"
 msgstr ""

--- a/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/block_scout_web/priv/gettext/en/LC_MESSAGES/default.po
@@ -226,7 +226,7 @@ msgid "Approximate Current Annual Percentage Yield. If you see N/A, please wait 
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:150
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:183
 msgid "Apps"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgid "Staker's Address"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:152
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:185
 msgid "Stakes"
 msgstr ""
 
@@ -1795,7 +1795,7 @@ msgid "Stakes Ratio"
 msgstr ""
 
 #, elixir-format
-#: lib/block_scout_web/templates/layout/_topnav.html.eex:158
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:191
 msgid "Staking"
 msgstr ""
 
@@ -2984,4 +2984,36 @@ msgstr ""
 #, elixir-format
 #: lib/block_scout_web/templates/chain/show.html.eex:41
 msgid "CRO Price"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:154
+msgid "Cronos Cosmos Mainnet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:165
+msgid "Cronos Cosmos Testnet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:146
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:159
+msgid "Cronos EVM Mainnet"
+msgstr ""
+
+#, elixir-format
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:148
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:170
+msgid "Cronos EVM Testnet"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:152
+msgid "Mainnets"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/block_scout_web/templates/layout/_topnav.html.eex:163
+msgid "Testnets"
 msgstr ""


### PR DESCRIPTION
Network switcher to switch between cosmos and EVM explorer . This change will require new environment variables (with the corresponding URLS):

```
export CHAIN_NETWORK=testnet
export COSMOS_EXPLORER_MAINNET_URL=https://cronos.crypto.org/explorer/cosmos/testnet3
export COSMOS_EXPLORER_TESTNET_URL=http://localhost:4002/
export EVM_EXPLORER_MAINNET_URL=https://cronos.crypto.org/explorer/evm/testnet3
export EVM_EXPLORER_TESTNET_URL=http://localhost:4000/
```

![image](https://user-images.githubusercontent.com/84574577/139602603-d725584d-f30b-4b18-bc42-f22561e41e8f.png)


