### PR TITLE
Fix: init emission_reward table

### DIFF
--- a/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
+++ b/apps/explorer/lib/explorer/chain_spec/genesis_data.ex
@@ -58,6 +58,8 @@ defmodule Explorer.ChainSpec.GenesisData do
   def fetch_genesis_data do
     path = Application.get_env(:explorer, __MODULE__)[:chain_spec_path]
 
+    GethImporter.init_emission_rewards()
+
     if path do
       json_rpc_named_arguments = Application.fetch_env!(:indexer, :json_rpc_named_arguments)
       variant = Keyword.fetch!(json_rpc_named_arguments, :variant)

--- a/apps/explorer/test/explorer/chain_spec/geth/importer_test.exs
+++ b/apps/explorer/test/explorer/chain_spec/geth/importer_test.exs
@@ -25,7 +25,7 @@ defmodule Explorer.ChainSpec.Geth.ImporterTest do
       assert first.block_range == %Range{from: 0, to: :infinity}
     end
   end
-  
+
   describe "genesis_accounts/1" do
     test "parses coin balance and contract code" do
       coin_balances = Importer.genesis_accounts(@genesis)

--- a/apps/explorer/test/explorer/chain_spec/geth/importer_test.exs
+++ b/apps/explorer/test/explorer/chain_spec/geth/importer_test.exs
@@ -5,9 +5,10 @@ defmodule Explorer.ChainSpec.Geth.ImporterTest do
   import EthereumJSONRPC, only: [integer_to_quantity: 1]
 
   alias Explorer.Chain.Address.{CoinBalance, CoinBalanceDaily}
-  alias Explorer.Chain.{Address, Hash}
+  alias Explorer.Chain.{Address, Hash, Wei}
   alias Explorer.ChainSpec.Geth.Importer
   alias Explorer.Repo
+  alias Explorer.Chain.Block.{EmissionReward, Range}
 
   setup :set_mox_global
 
@@ -15,6 +16,16 @@ defmodule Explorer.ChainSpec.Geth.ImporterTest do
            |> File.read!()
            |> Jason.decode!()
 
+  describe "init_emission_rewards/0" do
+    test "init emission rewards table" do
+      assert {1, nil} = Importer.init_emission_rewards()
+      [first] = Repo.all(EmissionReward)
+
+      assert first.reward == %Wei{value: Decimal.new(0)}
+      assert first.block_range == %Range{from: 0, to: :infinity}
+    end
+  end
+  
   describe "genesis_accounts/1" do
     test "parses coin balance and contract code" do
       coin_balances = Importer.genesis_accounts(@genesis)


### PR DESCRIPTION
*[Problem: Request “getblockreward” API failed](https://github.com/crypto-org-chain/cronos-blockscout/issues/15)*

## Issue cause

Empty table block_reward: when call this API, it will query the database which including the block_reward table and this will get the error like "{ "message": "Something went wrong.", "result": null, "status": "0" }"

## Issue Solution

Initialize the block_reward table.
