### PR TITLE
extend internal transaction timeout

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/geth.ex
@@ -87,7 +87,7 @@ defmodule EthereumJSONRPC.Geth do
   @tracer File.read!(@tracer_path)
 
   defp debug_trace_transaction_request(%{id: id, hash_data: hash_data}) do
-    request(%{id: id, method: "debug_traceTransaction", params: [hash_data, %{timeout: "20s", tracer: @tracer}]})
+    request(%{id: id, method: "debug_traceTransaction", params: [hash_data, %{timeout: "60s", tracer: @tracer}]})
   end
 
   defp debug_trace_transaction_responses_to_internal_transactions_params(


### PR DESCRIPTION
Extend `debug_traceTransaction` default timeout